### PR TITLE
Chore: docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code
+WORKDIR /code
+COPY requirements.txt /code/
+RUN pip install -r requirements.txt
+COPY . /code/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  db:
+    image: postgres
+    environment:
+      POSTGRES_PASSWORD: password
+  web:
+    build: .
+    command: python manage.py runserver 0.0.0.0:3001
+    restart: always
+    volumes:
+      - .:/code
+    ports:
+      - "3001:3001"
+    depends_on:
+      - db

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coreapi==2.3.3
-Django==2.2.6
+Django==2.2.10
 django-heroku==0.3.1
 django-rest-swagger==2.2.0
 djangorestframework==3.10.3


### PR DESCRIPTION
Add docker support for easier local development. We can now just do `docker-compose run` and the app will be ready to go.